### PR TITLE
Use standalone-firefox and refactor config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-app: &app
   environment: &env
     NODE_ENV: ${NODE_ENV:-development}
     RAILS_ENV: ${RAILS_ENV:-development}
-  image: x-app-dev:3.0.0
+  image: x-app-dev:3.0.1
   tmpfs:
     - /tmp
 
@@ -32,7 +32,7 @@ x-backend: &backend
     <<: *env
     REDIS_URL: redis://redis:6379/
     DATABASE_URL: postgres://postgres:postgres@postgres:5432
-    CHROME_URL: http://chrome:4444/wd/hub
+    REMOTE_SELENIUM_URL: http://standalone_browser:4444/wd/hub
     HISTFILE: /app/log/.bash_history
     PSQL_HISTFILE: /app/log/.psql_history
     EDITOR: vi
@@ -58,11 +58,11 @@ services:
       <<: *backend_environment
     depends_on: 
       <<: *backend_depends_on
-      chrome:
+      standalone_browser:
         condition: service_started
 
-  chrome:
-    image: seleniarm/standalone-chromium:4.0.0-beta-1-20210215
+  standalone_browser:
+    image: seleniarm/standalone-firefox:4.0.0-beta-1-20210215
     volumes: 
       - /dev/shm:/dev/shm
 
@@ -102,5 +102,5 @@ volumes:
   redis:
   bundle:
   rails_cache:
-  chrome:
+  standalone_browser:
   node_modules:

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -17,7 +17,7 @@ Capybara.register_driver :headless do |app|
   else
     require "webdrivers"
     Capybara::Selenium::Driver.new(app,
-      browser: :chrome,
+      browser: :firefox,
       capabilities: options)
   end
 end

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -2,17 +2,17 @@ require "capybara/rspec"
 
 Capybara.server = :puma, {Silent: true}
 
-Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
+Capybara.register_driver :headless do |app|
+  options = ::Selenium::WebDriver::Firefox::Options.new
   options.add_argument("--no-sandbox")
   options.add_argument("--headless")
   options.add_argument("--disable-gpu")
   options.add_argument("--window-size=2800,2800")
 
-  if ENV["CHROME_URL"]
+  if ENV["REMOTE_SELENIUM_URL"]
     Capybara::Selenium::Driver.new(app,
       browser: :remote,
-      url: ENV["CHROME_URL"],
+      url: ENV["REMOTE_SELENIUM_URL"],
       capabilities: options)
   else
     require "webdrivers"
@@ -24,7 +24,7 @@ end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) {
-    driven_by :chrome_headless
+    driven_by :headless
 
     capybara_host = IPSocket.getaddress(Socket.gethostname)
 


### PR DESCRIPTION
This PR passes on my M1 Docker setup

```bash
MacBook-Pro # dip rspec system                                                                                                                                                                       (main) [~/code/pbcbv/template-applications/app]
Creating app_rspec_system_run ... done

🐢  Running NPM Build.
Finished in 0.2 seconds
.

Finished in 6.79 seconds (files took 8 seconds to load)
1 example, 0 failures
```