### PR TITLE
Remove superflous and ancient step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gem-
-
       - name: Install dependencies
         run: |
           sudo apt-get -yqq install libpq-dev


### PR DESCRIPTION
The ruby/setup-ruby@v1 already caches gems and removing this one decreases the time to test everything with around 10 minutes on a repo using this template.