### PR TITLE
Enable asset-url in css

### DIFF
--- a/config/initializers/asset_url_processor.rb
+++ b/config/initializers/asset_url_processor.rb
@@ -1,0 +1,11 @@
+class AssetUrlProcessor
+  def self.call(input)
+    context = input[:environment].context_class.new(input)
+    data = input[:data].gsub(/asset-url\(["']?(.+?)["']?\)/) do |_match|
+      "url(#{context.asset_path($1)})"
+    end
+    {data: data}
+  end
+end
+
+Sprockets.register_postprocessor "text/css", AssetUrlProcessor


### PR DESCRIPTION
this will use the asset pipeline to load the correct asset in
the css.

for example, with `app/assets/images/landing/header-img.png` you can use
`asset-url` in your plain css like so:

```css
.landing-header {
  @media (min-width: 640px) {
    background: asset-url("landing/header-img.png") no-repeat;

```